### PR TITLE
Network serial support & bug fixes

### DIFF
--- a/psu.py
+++ b/psu.py
@@ -409,7 +409,7 @@ def main():
     opts=OptionParser(usage='Provide a control interface to the ROCKSEED RS310P/RS305P Bench PSU.')
     opts.add_option("--debug",      help="Enable debugging.", action="store_true", default=False)
     opts.add_option("-g",           help="Run the GUI.", action="store_true", default=False)
-    opts.add_option("-p",           help="Serial port (default={}).".format(PSU.DEFAULT_SERIAL_PORT), default=PSU.DEFAULT_SERIAL_PORT)
+    opts.add_option("-p",           help="Serial port (default={}). Enter in 'host:port' format for an Esp-Link bridge.".format(PSU.DEFAULT_SERIAL_PORT), default=PSU.DEFAULT_SERIAL_PORT)
     opts.add_option("-v",           help="The required output voltage.", type="float", default=-1)
     opts.add_option("-a",           help="The current limit value in amps.", type="float", default=-1)
     opts.add_option("-s",           help="The PSU status showing output state, voltage, current and power out.", action="store_true", default=False)
@@ -430,6 +430,10 @@ def main():
 
     try:
         (options, args) = opts.parse_args()
+
+        if ':' in options.p:
+            host, port = options.p.split(':')
+            options.p = (host, int(port))
 
         psu = PSU(uio, options)
         psu.process()

--- a/view.py
+++ b/view.py
@@ -21,7 +21,7 @@ from bokeh.server.server import Server
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.plotting import figure, ColumnDataSource
-from bokeh.models import Range1d
+from bokeh.models import Range1d, AutocompleteInput
 from bokeh.palettes import Category20_20 as palette
 
 from bokeh.plotting import save, output_file
@@ -163,8 +163,8 @@ class PSUGUI(TabbedGUI):
         self._figTable[-1].append(fig)
         self._grid = gridplot(children = self._figTable, sizing_mode = 'scale_both',  toolbar_location='right')
 
-        self.selectSerialPort = Select(title="Serial Port:")
-        self.selectSerialPort.options = glob.glob('/dev/ttyU*')
+        self.selectSerialPort = AutocompleteInput(title="Serial Port:")
+        self.selectSerialPort.completions = glob.glob('/dev/ttyU*')
         
         self.outputVoltageSpinner = Spinner(title="Output Voltage (Volts)", low=0, high=40, step=0.5, value=self._pconfig.getAttr(PSUGUI.VOLTS))
         self.currentLimitSpinner = Spinner(title="Currnet Limit (Amps)", low=0, high=10, step=0.25, value=self._pconfig.getAttr(PSUGUI.AMPS))
@@ -295,16 +295,11 @@ class PSUGUI(TabbedGUI):
     def getSelectedSerialPort(self):
         """@brief Get the selected serial port.
            @return the selected Serial port or None if not selected."""
-        selectedSerialPort = None
-        if len(self.selectSerialPort.options) == 1:
-            selectedSerialPort = self.selectSerialPort.options[0]
-        elif self.selectSerialPort.value:
-            selectedSerialPort = self.selectSerialPort.value
-        
-        if not selectedSerialPort and len(self.selectSerialPort.options) > 0:
-            selectedSerialPort = self.selectSerialPort.options[0]
-            
-        return selectedSerialPort
+        if ':' in self.selectSerialPort.value_input:
+            # hostname & port
+            return self.selectSerialPort.value_input.split(':')
+        else:
+            return self.selectSerialPort.value_input
 
     def _psuOff(self):
         """@brief Turn the PSU off."""
@@ -346,5 +341,4 @@ class PSUGUI(TabbedGUI):
             else:
                 self._sendUpdateEvent( UpdateEvent(PSUGUIUpdateEvent.PSU_CONNECT_FAILED, ("Failed to connect to PSU on {}".format(serialPort),) ) ) 
                 self.setStatus("Failed to connect to PSU.")
-            
             

--- a/view.py
+++ b/view.py
@@ -76,8 +76,8 @@ class PSUGUI(TabbedGUI):
     VOLTS = "volts"
     PLOT_SECONDS = "plotSeconds"
     CFG_DICT = {
-        VOLTS: "5",
-        AMPS: "1",
+        VOLTS: 5,
+        AMPS: 1,
         PLOT_SECONDS: 300
     }
     def __init__(self, docTitle, bokehPort=12000):
@@ -134,7 +134,7 @@ class PSUGUI(TabbedGUI):
             
     def _updatePlot(self, volts, amps, watts):
         """@brief called periodically to update the plot trace."""
-        plotPoints = self.plotHistorySpinner.value*2
+        plotPoints = int(self.plotHistorySpinner.value*2)
         now = datetime.now()     
         newVolts = {'x': [now],
                     'y': [volts]}
@@ -166,9 +166,9 @@ class PSUGUI(TabbedGUI):
         self.selectSerialPort = AutocompleteInput(title="Serial Port:")
         self.selectSerialPort.completions = glob.glob('/dev/ttyU*')
         
-        self.outputVoltageSpinner = Spinner(title="Output Voltage (Volts)", low=0, high=40, step=0.5, value=self._pconfig.getAttr(PSUGUI.VOLTS))
-        self.currentLimitSpinner = Spinner(title="Currnet Limit (Amps)", low=0, high=10, step=0.25, value=self._pconfig.getAttr(PSUGUI.AMPS))
-        self.plotHistorySpinner = Spinner(title="Plot History (Seconds)", low=1, high=10000, step=1, value=self._pconfig.getAttr(PSUGUI.PLOT_SECONDS))
+        self.outputVoltageSpinner = Spinner(title="Output Voltage (Volts)", low=0, high=40, step=0.5, value=float(self._pconfig.getAttr(PSUGUI.VOLTS)))
+        self.currentLimitSpinner = Spinner(title="Currnet Limit (Amps)", low=0, high=10, step=0.25, value=float(self._pconfig.getAttr(PSUGUI.AMPS)))
+        self.plotHistorySpinner = Spinner(title="Plot History (Seconds)", low=1, high=10000, step=1, value=float(self._pconfig.getAttr(PSUGUI.PLOT_SECONDS)))
         
         self._setButton = Button(label="Set")
         self._setButton.on_click(self._setHandler)


### PR DESCRIPTION
I've added support for the ESP-Link serial port to wifi adapter I've put into my system, and I've fixed a few exceptions that I ran into.

The only change that might be controversial here is replacing the serial port GUI element with an Autocomplete element where the user needs to type in the first 3 letters of the target port before the autocomplete will provide the ability to select it.